### PR TITLE
feat: Added streamByItag function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
             ],
             "rules": {
                 "no-console": "off",
+                "import/no-unresolved": "off",
                 "@typescript-eslint/no-unused-vars": "off"
             },
             "parserOptions": {

--- a/README.md
+++ b/README.md
@@ -32,26 +32,26 @@ npm install @ytdl/ytdl -g
 
 ### Via curl
 
-### As a single file (from latest Github Release):
+- As a single file (from latest Github Release):
 ```bash
 # Needs both curl and wget
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ytdl-node/ytdl/master/bin/install-latest)"
 ```
 
-### From GitHub repository:
+- From GitHub repository:
 ```bash
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ytdl-node/ytdl/master/bin/install)"
 ```
 
 ### Via wget
 
-### As a single file (from latest Github Release):
+- As a single file (from latest Github Release):
 ```bash
 # Needs both curl and wget
 sh -c "$(wget -O- https://raw.githubusercontent.com/ytdl-node/ytdl/master/bin/install-latest)"
 ```
 
-### From GitHub repository:
+- From GitHub repository:
 ```bash
 sh -c "$(wget -O- https://raw.githubusercontent.com/ytdl-node/ytdl/master/bin/install)"
 ```

--- a/README.md
+++ b/README.md
@@ -265,6 +265,49 @@ ytdl('https://www.youtube.com/watch?v=fJ9rUzIMcZQ').then((video) => {
 });
 ```
 
+### video.streamByItag()
+
+```javascript
+const ytdl = require('@ytdl/ytdl').default;
+const fs = require('fs');
+
+async function download() {
+  const video = await ytdl('https://www.youtube.com/watch?v=fJ9rUzIMcZQ');
+  const stream = await video.stream(18);
+  // The variable stream now holds a Node.js stream.
+  // Sample use of stream is as follows:
+  stream
+    .pipe(fs.createWriteStream('ytdl.mp4'))
+    .on('finish', (err) => {
+      if (err) console.log(err);
+      else console.log('Stream saved successfully.');
+    });
+}
+
+download();
+```
+
+### OR
+
+```javascript
+// Without using async-await.
+const ytdl = require('@ytdl/ytdl').default;
+const fs = require('fs');
+
+ytdl('https://www.youtube.com/watch?v=fJ9rUzIMcZQ').then((video) => {
+  video.streamByItag(18).then((stream) => {
+    // The variable stream now holds a Node.js stream.
+    // Sample use of stream is as follows:
+    stream
+      .pipe(fs.createWriteStream('ytdl.mp4'))
+      .on('finish', (err) => {
+        if (err) console.log(err);
+        else console.log('Stream saved successfully.');
+      });
+  });
+});
+```
+
 ## video.setLogLevel(level)
 
 - `level` can be one of the following:

--- a/README.md
+++ b/README.md
@@ -265,7 +265,9 @@ ytdl('https://www.youtube.com/watch?v=fJ9rUzIMcZQ').then((video) => {
 });
 ```
 
-### video.streamByItag()
+### video.streamByItag(itag[, headers])
+
+- Same functionality as [`video.stream(quality)`](#videostreamquality-options-headers), uses `itag` instead of `quality`.
 
 ```javascript
 const ytdl = require('@ytdl/ytdl').default;

--- a/config/tsconfig.examples.json
+++ b/config/tsconfig.examples.json
@@ -6,6 +6,7 @@
     },
     "files": [
         "../examples/ytdl.example.js",
+        "../examples/stream.example.js",
         "../examples/ytdl.example.ts"
     ]
 }

--- a/examples/stream.example.js
+++ b/examples/stream.example.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const ytdl = require('@ytdl/ytdl');
+
+const app = express();
+
+app.listen(process.env.PORT || 3000, () => {
+    console.log(`Listening on port: ${process.env.PORT || 3000}`);
+});
+
+async function streamer(link) {
+    const video = await ytdl.init(link);
+    const stream = await video.stream('360p');
+    const { title } = video.info.all();
+    return { stream, title };
+}
+
+app.get('/download', async (req, res) => {
+    const { link } = req.query;
+    console.log(link);
+
+    if (!link) {
+        res.send('Send link as request query with name link.');
+        return;
+    }
+
+    try {
+        const { stream, title } = await streamer(link);
+
+        res.header('Content-Disposition', `attachment; filename="${title}.mp4"`);
+        stream.pipe(res);
+    } catch (err) {
+        res.send('Error has occurred.');
+    }
+});

--- a/examples/stream.example.js
+++ b/examples/stream.example.js
@@ -3,10 +3,16 @@ const ytdl = require('@ytdl/ytdl');
 
 const app = express();
 
+/**
+ * Start server on port 3000.
+ */
 app.listen(process.env.PORT || 3000, () => {
     console.log(`Listening on port: ${process.env.PORT || 3000}`);
 });
 
+/**
+ * Returns a Node.js stream and the video title.
+ */
 async function streamer(link) {
     const video = await ytdl.init(link);
     const stream = await video.stream('360p');
@@ -14,6 +20,9 @@ async function streamer(link) {
     return { stream, title };
 }
 
+/**
+ * Get request of the form: http://localhost:3000/download?link=<youtubeLink>
+ */
 app.get('/download', async (req, res) => {
     const { link } = req.query;
     console.log(link);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ytdl/ytdl",
-    "version": "1.1.16",
+    "version": "1.1.17",
     "description": "A CLI/Library written in typescript/javascript, which allows you to download videos from [YouTube](http://youtube.com) onto your system.",
     "keywords": [
         "youtube",

--- a/src/ytdl.ts
+++ b/src/ytdl.ts
@@ -125,4 +125,17 @@ export default class Ytdl {
 
         return this.videoDownloader.stream(headers);
     }
+
+    public async streamByItag(itag: number, headers?: object) {
+        const { url } = this.info.fetchFormatDataByItag(itag);
+        if (!url) {
+            return Promise.resolve();
+        }
+
+        if (!this.videoDownloader || !(this.videoDownloader.url === url)) {
+            this.videoDownloader = new VideoDownloader(url);
+        }
+
+        return this.videoDownloader.stream(headers);
+    }
 }


### PR DESCRIPTION
- Same functionality as [`video.stream(quality)`](https://github.com/ytdl-node/ytdl#videostreamquality-options-headers), uses `itag` instead of `quality`.
